### PR TITLE
Possible AWS S3 fix

### DIFF
--- a/utils/aws.py
+++ b/utils/aws.py
@@ -12,7 +12,7 @@ class S3Instance:
         def __init__(self, bucket):
             self.bucketName = bucket
             self.session = boto3.Session(aws_access_key_id=os.getenv("AWS_KEY_ID"), aws_secret_access_key=os.getenv("AWS_SECRET_KEY"))
-            self.resource = boto3.resource("s3")
+            self.resource = self.session.resource("s3")
             self.bucket = self.resource.Bucket(name=bucket)
     
     def __init__(self):


### PR DESCRIPTION
Context:
boto3 works with sessions, which can be created via parameters to the constructor, if you do not use a session object, boto3 will read credentials from files on `~/.aws` and then create the session for you.
The problem was that, I though that by creating a session from parameters, boto3 would use the new session by itself, it does not, so, in a nutshell, I was creating a session from both the files and the parameters, but since I didn't explicitly use the params session, boto3 used the session from files. And those files do not exist on our EBS.

So I deleted those files from my PC, and explicitly used the new session, and it worked!
